### PR TITLE
Implement new Concept "junit4:RunWith"

### DIFF
--- a/src/main/asciidoc/release-notes.adoc
+++ b/src/main/asciidoc/release-notes.adoc
@@ -1,6 +1,11 @@
 
 = JUnit Plugin
 
+== 1.11.0
+
+* Added new concept `junit4:RunWith`
+** This concept labels all classes annotated with `org.junit.runner.RunWith` with `Junit4` and `Test`.
+
 == 1.10.0
 
 * Added support for additional assert methods to concept `junit5:AssertMethod`.

--- a/src/main/resources/META-INF/jqassistant-rules/junit4.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/junit4.xml
@@ -161,4 +161,15 @@
       ]]></cypher>
     </concept>
 
+    <concept id="junit4:RunWith">
+        <description>Labels all classes annotated with org.junit.runner.RunWith with "Junit4" and "Test".</description>
+        <cypher><![CDATA[
+            MATCH
+                (source:Type)-[r:ANNOTATED_BY]->(target)-[x:OF_TYPE]-(y {fqn:"org.junit.runner.RunWith"})
+            SET
+                source:Junit4:Test
+            RETURN
+                source
+        ]]></cypher>
+    </concept>
 </jqa:jqassistant-rules>

--- a/src/main/resources/META-INF/jqassistant-rules/junit4.xml
+++ b/src/main/resources/META-INF/jqassistant-rules/junit4.xml
@@ -165,7 +165,7 @@
         <description>Labels all classes annotated with org.junit.runner.RunWith with "Junit4" and "Test".</description>
         <cypher><![CDATA[
             MATCH
-                (source:Type)-[r:ANNOTATED_BY]->(target)-[x:OF_TYPE]-(y {fqn:"org.junit.runner.RunWith"})
+                (source:Type)-[:ANNOTATED_BY]->(target)-[:OF_TYPE]->({fqn:"org.junit.runner.RunWith"})
             SET
                 source:Junit4:Test
             RETURN

--- a/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
@@ -241,7 +241,7 @@ public class Junit4IT extends AbstractJunitIT {
         scanClasses(EnclosedTestClass.class);
         assertThat(applyConcept("junit4:RunWith").getStatus(), equalTo(SUCCESS));
         store.beginTransaction();
-        List<Object> methods = query("match (m:Junit4:Test {name:\"EnclosedTestClass\"}) return m").getColumn("m");
+        List<Object> methods = query("MATCH (m:Junit4:Test {name:\"EnclosedTestClass\"}) RETURN m").getColumn("m");
         assertThat(methods, hasItem(typeDescriptor(EnclosedTestClass.class)));
         store.commitTransaction();
     }

--- a/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/junit/test/rule/Junit4IT.java
@@ -9,12 +9,10 @@ import com.buschmais.jqassistant.core.rule.api.model.Constraint;
 import com.buschmais.jqassistant.core.rule.api.model.RuleException;
 import com.buschmais.jqassistant.plugin.common.test.scanner.MapBuilder;
 import com.buschmais.jqassistant.plugin.java.api.model.MethodDescriptor;
-import com.buschmais.jqassistant.plugin.junit.test.set.junit4.Assertions4Junit4;
-import com.buschmais.jqassistant.plugin.junit.test.set.junit4.IgnoredTest;
-import com.buschmais.jqassistant.plugin.junit.test.set.junit4.TestClass;
-import com.buschmais.jqassistant.plugin.junit.test.set.junit4.TestSuite;
+import com.buschmais.jqassistant.plugin.junit.test.set.junit4.*;
 
 import org.junit.Assert;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.jupiter.api.Test;
 
 import static com.buschmais.jqassistant.core.report.api.model.Result.Status.SUCCESS;
@@ -232,6 +230,19 @@ public class Junit4IT extends AbstractJunitIT {
         store.beginTransaction();
         List<Object> methods = query("match (m:AfterClass:Junit4:Method) return m").getColumn("m");
         assertThat(methods, hasItem(methodDescriptor(TestClass.class, "afterClass")));
+        store.commitTransaction();
+    }
+
+    /**
+     * Verifies the concept "junit4:RunWith".
+     */
+    @Test
+    public void runWith() throws Exception {
+        scanClasses(EnclosedTestClass.class);
+        assertThat(applyConcept("junit4:RunWith").getStatus(), equalTo(SUCCESS));
+        store.beginTransaction();
+        List<Object> methods = query("match (m:Junit4:Test {name:\"EnclosedTestClass\"}) return m").getColumn("m");
+        assertThat(methods, hasItem(typeDescriptor(EnclosedTestClass.class)));
         store.commitTransaction();
     }
 

--- a/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit4/EnclosedTestClass.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit4/EnclosedTestClass.java
@@ -1,0 +1,25 @@
+package com.buschmais.jqassistant.plugin.junit.test.set.junit4;
+
+import org.junit.*;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+/**
+ * A JUnit4 test classes using enclosed test classes.
+ */
+@RunWith(Enclosed.class)
+public class EnclosedTestClass {
+
+    public static class FirstTest {
+        @Test
+        public void testMethod() {
+        }
+    }
+
+    public static class SecondTest {
+        @Test
+        public void testMethod() {
+        }
+    }
+
+}

--- a/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit4/EnclosedTestClass.java
+++ b/src/test/java/com/buschmais/jqassistant/plugin/junit/test/set/junit4/EnclosedTestClass.java
@@ -5,7 +5,7 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
 /**
- * A JUnit4 test classes using enclosed test classes.
+ * A JUnit 4 test classes using enclosed test classes.
  */
 @RunWith(Enclosed.class)
 public class EnclosedTestClass {


### PR DESCRIPTION
Implements jQAssistant/jqassistant#460 

RunWIth does only exist in Junit 4, in Junit 5 it was replaced by `@ExtendWith`, therefore an implemention is only provided for Junit 4.